### PR TITLE
Removed use of readAsBinaryString to replace with readAsArrayBuffer

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -489,7 +489,6 @@ var EXIF = (function() {
 	}
 	
     function readEXIFData(file, start) {
-		console.log(start);
         if (getStringFromDB(file, start, 4) != "Exif") {
             if (debug) console.log("Not valid EXIF data! " + getStringFromDB(file, start, 4));
             return false;


### PR DESCRIPTION
The readAsBinaryString routine is not supported in IE10. This commit removes the use
of that routine and replaces it with readAsArrayBuffer. It also logs a
few extra things to the console in debug mode. I've tested it in IE10, Firefox 22 and Chrome 28.

I tried not to rename too many variables - however, it maybe makes sense to rename "file" (used throughout) as it is really an ArrayBuffer now, and also it might be a good idea to replace "bigendian" with "littleendian", because it keeps getting used as !bigendian in the code I added.

This is the first time I've actually tried to contribute something to someone else's GitHub project, and I am something of a source-control newbie in general. So my humble apologies if I've gone about this in some sort of way that will earn me the scourge of the internet community. Let me know if I've done something wrong and I'll do it another way! This library was a lifesaver for a project I've been working on, so hopefully my edits will be some use.
