### PR TITLE
Allow to pass a Blob to getData (so that only the first 128kb can be processed by EXIF)

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -318,7 +318,7 @@ var EXIF = (function() {
             BinaryAjax(img.src, function(http) {
                 handleBinaryFile(http.binaryResponse);
             });
-        } else if (window.FileReader && img instanceof window.File) {
+        } else if (window.FileReader && img instanceof window.Blob) {
             var fileReader = new FileReader();
 
             fileReader.onload = function(e) {


### PR DESCRIPTION
For large images it might be more efficient to only process the first 128kb (see e.g. http://code.flickr.net/2012/06/01/parsing-exif-client-side-using-javascript-2/).

To pass only the first 128kb to EXIF one can use `file.slice(0, 131072)`. The result then is of type window.Blob and no longer a window.File, so the check in `EXIF.getImageData` has to be adjusted.

A full example of what this change allows to do:

```
var getFilePart = function(file) {
    // From http://code.flickr.net/2012/06/01/parsing-exif-client-side-using-javascript-2/:
    // Using Blob.slice() we pull out the first 128kb of the image to limit load on the worker
    // and speed things up. The Exif specification states that all of the data should exist in
    // the first 64kb, but IPTC sometimes goes beyond that, especially when formatted as XMP.
    var filePart;
    if (file.slice) {
        filePart = file.slice(0, 131072);
    } else if (file.webkitSlice) {
        filePart = file.webkitSlice(0, 131072);
    } else if (file.mozSlice) {
        filePart = file.mozSlice(0, 131072);
    } else {
        filePart = file;
    }
    return filePart;
}

var filePart = getFilePart(file);
EXIF.getData(filePart, function() {
    var tags = EXIF.getAllTags(filePart);
    console.log("Got tags ", tags);
});
```
