### PR TITLE
Accepting File and Blob (see issue #7)

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -1,4 +1,3 @@
-
 var EXIF = (function() {
 
     var debug = false;
@@ -312,7 +311,7 @@ var EXIF = (function() {
             BinaryAjax(img.src, function(http) {
                 handleBinaryFile(http.binaryResponse);
             });
-        } else if (window.FileReader && img instanceof window.File) {
+        } else if (window.FileReader && (img instanceof window.Blob || img instanceof window.File)) {
             var fileReader = new FileReader();
 
             fileReader.onload = function(e) {


### PR DESCRIPTION
This allows passing only the first 128 (or 64) KB of the file, saving memory and other resources. Especially useful with very big pictures.

Code sample (taken from comment on issue #7):

``` javascript
function getFilePart(file) {
    // From http://code.flickr.net/2012/06/01/parsing-exif-client-side-using-javascript-2/:
    // Using Blob.slice() we pull out the first 128kb of the image to limit load on the worker
    // and speed things up. The Exif specification states that all of the data should exist in
    // the first 64kb, but IPTC sometimes goes beyond that, especially when formatted as XMP.
    var filePart
    if (file.slice) {
        filePart = file.slice(0, 131072)
    } else if (file.webkitSlice) {
        filePart = file.webkitSlice(0, 131072)
    } else if (file.mozSlice) {
        filePart = file.mozSlice(0, 131072)
    } else {
        filePart = file
    }
    return filePart
}

var filePart = getFilePart(someFile)
EXIF.getData(filePart, function() {
    if(callback) callback(EXIF.getAllTags(this))
})
```
