### PR TITLE
Make getData() more flexible for remote and local images

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -368,7 +368,7 @@
             } else {
                 var http = new XMLHttpRequest();
                 http.onload = function() {
-                    if (http.status == "200") {
+                    if (this.status == 200 || this.status === 0) {
                         handleBinaryFile(http.response);
                     } else {
                         throw "Could not load image";


### PR DESCRIPTION
Make getData() more flexible, by allowing any object with a src property to be passed to it. This is useful to avoid unnecessary requests triggered if you set src on an Image object, so you can directly load a remote image without having to create such an object, e.g.

```
EXIF.getData({src: 'http://my.image.url'}, function () { ... });
```

I also modified the condition which checks whether the Ajax request completed correctly, so that it doesn't rely on status 200 (it is 0 for local files).
