### PR TITLE
Fixes #33: Refactored global registration

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -1,4 +1,16 @@
-(function() {
+(function(root, factory){
+    if (typeof exports !== 'undefined') {
+        if (typeof module !== 'undefined' && module.exports) {
+            exports = module.exports = factory();
+        } else {
+            exports.EXIF = factory();
+        }
+    } else if (typeof define === 'function' && define.amd) {
+        define(factory);
+    } else {
+        root.EXIF = factory();
+    }
+}(this, function() {
 
     var debug = false;
 
@@ -9,15 +21,6 @@
         if (!(this instanceof EXIF)) return new EXIF(obj);
         this.EXIFwrapped = obj;
     };
-
-    if (typeof exports !== 'undefined') {
-        if (typeof module !== 'undefined' && module.exports) {
-            exports = module.exports = EXIF;
-        }
-        exports.EXIF = EXIF;
-    } else {
-        root.EXIF = EXIF;
-    }
 
     var ExifTags = EXIF.Tags = {
 
@@ -796,10 +799,5 @@
         return findEXIFinJPEG(file);
     }
 
-    if (typeof define === 'function' && define.amd) {
-        define('exif-js', [], function() {
-            return EXIF;
-        });
-    }
-}.call(this));
-
+    return EXIF;
+}));


### PR DESCRIPTION
This slightly different registration provides a more robust way to incorporate into other libraries. I cleaned up the registration to all be in one place and passed the factory function to define instead of declaring a static name for the library: 'exif-js'. This way it can be called by its file name.
