### PR TITLE
Support for XP tags used by windows systems

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -129,7 +129,11 @@
         0x0131 : "Software",
         0x013B : "Artist",
         0x8298 : "Copyright",
-        0x9c9e : "XPKeywords"
+        0x9c9b : "XPTitle",
+        0x9c9c : "XPComment",
+        0x9c9d : "XPAuthor",
+        0x9c9e : "XPKeywords",
+        0x9c9f : "XPSubject"
     };
 
     var GPSTags = EXIF.GPSTags = {


### PR DESCRIPTION
I added decoding of tags used by windows starting with XP. They are decoded as byte array, which needs to be further decoded into e.g. string using:
String.fromCharCode.apply(String, this.exifdata["XPKeywords"]);
