### PR TITLE
Pass an Error to the callback instead of throw'ing

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -371,7 +371,7 @@
                     if (this.status == 200 || this.status === 0) {
                         handleBinaryFile(http.response);
                     } else {
-                        throw "Could not load image";
+                        callback(new Error("Could not load image"));
                     }
                     http = null;
                 };


### PR DESCRIPTION
Throwing in an async handler results in an uncaught exception which
can never be handled by the consumer. Instead, invoke the callback
with an Error instance as the first argument (the callback is never
invoked with any arguments so this does not break the API).
