### PR TITLE
add var in for loop

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -642,7 +642,7 @@
 
     function getStringFromDB(buffer, start, length) {
         var outstr = "";
-        for (n = start; n < start+length; n++) {
+        for (var n = start; n < start+length; n++) {
             outstr += String.fromCharCode(buffer.getUint8(n));
         }
         return outstr;


### PR DESCRIPTION
If exif-js is required as a module then it throws an `Uncaught ReferenceError: n is not defined`. Adding the proper scoping with var solves this issue.
