### PR TITLE
Add gps Positioning error tag 0X001f

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -162,7 +162,9 @@
         0x001B : "GPSProcessingMethod",
         0x001C : "GPSAreaInformation",
         0x001D : "GPSDateStamp",
-        0x001E : "GPSDifferential"
+        0x001E : "GPSDifferential",
+        0x001f : "GPSHPositioningError"
+
     };
 
      // EXIF 2.3 Spec


### PR DESCRIPTION
This tag allow the access to the GPS positioning accuracy on iOS's recorded exif.