### PR TITLE
Explicit var declaration

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -738,7 +738,7 @@
 
     function getStringFromDB(buffer, start, length) {
         var outstr = "";
-        for (n = start; n < start+length; n++) {
+        for (var n = start; n < start+length; n++) {
             outstr += String.fromCharCode(buffer.getUint8(n));
         }
         return outstr;


### PR DESCRIPTION
Missing `var` causes an error in strict mode where there doesn't need to be and it otherwise works.