### PR TITLE
Skip broken GPSVersionID

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -823,10 +823,12 @@
             for (tag in gpsData) {
                 switch (tag) {
                     case "GPSVersionID" :
-                        gpsData[tag] = gpsData[tag][0] +
-                            "." + gpsData[tag][1] +
-                            "." + gpsData[tag][2] +
-                            "." + gpsData[tag][3];
+                        if (gpsData[tag]) {
+                            gpsData[tag] = gpsData[tag][0] +
+                                "." + gpsData[tag][1] +
+                                "." + gpsData[tag][2] +
+                                "." + gpsData[tag][3];
+                        }
                         break;
                 }
                 tags[tag] = gpsData[tag];


### PR DESCRIPTION
We have a Huawei Nexus (Android) phone which somehow managed to take pictures with some broken EXIF data. This breaks our web app when we try to run it through our photo uploader that relies on exif-js. `TypeError: gpsData[tag] is undefined`. Obviously the phone shouldn't write EXIF data like that, but **it did**, which means our user's phones might do the same.

I'm attaching an example photo here, you can save it, rename to `Bloated-Hero.jpg` or whatever and run it through the example in this repo and you'll see the `EXIF.getData` call fail.

![img_20180424_153459](https://user-images.githubusercontent.com/6059552/40308909-06a55a3c-5d08-11e8-9350-a00d7e397205.jpg)
