### PR TITLE
Skip non Exif APP1 marker

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -443,7 +443,7 @@
             // we could implement handling for other markers here,
             // but we're only looking for 0xFFE1 for EXIF data
 
-            if (marker == 225) {
+            if (marker == 225 && getStringFromDB(dataView, offset + 4, 4) === "Exif") {
                 if (debug) console.log("Found 0xFFE1 marker");
 
                 return readEXIFData(dataView, offset + 4, dataView.getUint16(offset + 2) - 2);


### PR DESCRIPTION
This PR skips APP1 markers that are not EXIF.

The issue can be observed from 360 pictures taken with a GoPro Fusion camera.
In the following screenshot it can be observed that the first APP1 marker is used to add XMP tags.

![image](https://user-images.githubusercontent.com/1209171/44168086-6851b280-a0a6-11e8-9405-cc578eed96f5.png)

Given this line https://github.com/exif-js/exif-js/blob/master/exif.js#L748, I'm not sure if GoPro Fusion follows the standard.