### PR TITLE
Expose XMLHttpRequest errors

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -365,7 +365,7 @@
         http.send();
     }
 
-    function getImageData(img, callback) {
+    function getImageData(img, onSuccess, onError) {
         function handleBinaryFile(binFile) {
             var data = findEXIFinJPEG(binFile);
             img.exifdata = data || {};
@@ -375,8 +375,8 @@
                var xmpdata= findXMPinJPEG(binFile);
                img.xmpdata = xmpdata || {};               
             }
-            if (callback) {
-                callback.call(img);
+            if (onSuccess) {
+                onSuccess.call(img);
             }
         }
 
@@ -395,13 +395,16 @@
                 });
             } else {
                 var http = new XMLHttpRequest();
-                http.onload = function() {
+                http.onload = function(e) {
                     if (this.status == 200 || this.status === 0) {
                         handleBinaryFile(http.response);
                     } else {
-                        throw "Could not load image";
+                        return onError && onError(e);
                     }
                     http = null;
+                };
+                http.onerror = function(e) {
+                    return onError && onError(e);
                 };
                 http.open("GET", img.src, true);
                 http.responseType = "arraybuffer";

--- a/exif.js
+++ b/exif.js
@@ -375,9 +375,7 @@
                var xmpdata= findXMPinJPEG(binFile);
                img.xmpdata = xmpdata || {};               
             }
-            if (onSuccess) {
-                onSuccess.call(img);
-            }
+            return onSuccess && onSuccess.call(img);
         }
 
         if (img.src) {


### PR DESCRIPTION
Currently there's no way to handle XMLHttpRequest errors on the calling side.
Adding an error callback and calling it when we get a response but the status isn't 200 and when the request fails altogether.