### PR TITLE
allow error during EXIF.getData() to be handled

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -367,17 +367,24 @@
 
     function getImageData(img, callback) {
         function handleBinaryFile(binFile) {
-            var data = findEXIFinJPEG(binFile);
-            img.exifdata = data || {};
-            var iptcdata = findIPTCinJPEG(binFile);
-            img.iptcdata = iptcdata || {};
-            if (EXIF.isXmpEnabled) {
-               var xmpdata= findXMPinJPEG(binFile);
-               img.xmpdata = xmpdata || {};               
-            }
-            if (callback) {
-                callback.call(img);
-            }
+          try {
+              var data = findEXIFinJPEG(binFile);
+              img.exifdata = data || {};
+              var iptcdata = findIPTCinJPEG(binFile);
+              img.iptcdata = iptcdata || {};
+              if (EXIF.isXmpEnabled) {
+                 var xmpdata= findXMPinJPEG(binFile);
+                 img.xmpdata = xmpdata || {};
+              }
+              if (callback) {
+                  callback.call(img);
+              }
+          } catch (e) {
+              if (debug) console.error("An error occurred while handling binary file:", e);
+              if (callback) {
+                  callback.call(img, e);
+              }
+          }
         }
 
         if (img.src) {
@@ -892,7 +899,7 @@
 
     function xml2json(xml) {
         var json = {};
-      
+
         if (xml.nodeType == 1) { // element node
           if (xml.attributes.length > 0) {
             json['@attributes'] = {};
@@ -904,7 +911,7 @@
         } else if (xml.nodeType == 3) { // text node
           return xml.nodeValue;
         }
-      
+
         // deal with children
         if (xml.hasChildNodes()) {
           for(var i = 0; i < xml.childNodes.length; i++) {
@@ -922,7 +929,7 @@
             }
           }
         }
-        
+
         return json;
     }
 
@@ -993,7 +1000,7 @@
         if (!imageHasData(img)) return;
         return img.exifdata[tag];
     }
-    
+
     EXIF.getIptcTag = function(img, tag) {
         if (!imageHasData(img)) return;
         return img.iptcdata[tag];
@@ -1011,7 +1018,7 @@
         }
         return tags;
     }
-    
+
     EXIF.getAllIptcTags = function(img) {
         if (!imageHasData(img)) return {};
         var a,
@@ -1056,4 +1063,3 @@
         });
     }
 }.call(this));
-


### PR DESCRIPTION
I get this error when processing an image that has an unknown tag (from debug output):

"Unknown tag: 18758"

The main problem, however, isn't the specific error.  It's that this error get's thrown and the callback is never called, preventing the calling code from handling the error.

I added an error handler that will pass the error back in the callback when something throws and guarantee the callback gets called.

Great library, btw.  Its helped me a ton!