### PR TITLE
63 offset outside of bounds dataview

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -575,9 +575,9 @@
                     if (debug) {
                         console.log("Offset is outside the bounds of the DataView");
                     }
-                    else {
-                        tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
-                    }
+                }
+                else {
+                    tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
                 }
             }
         }

--- a/exif.js
+++ b/exif.js
@@ -569,13 +569,6 @@
             entryOffset = dirStart + i*12 + 2;
             tag = strings[file.getUint16(entryOffset, !bigEnd)];
             if (!tag && debug) console.log("Unknown tag: " + file.getUint16(entryOffset, !bigEnd));
-            tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
-        }
-
-        for (i=0;i<entries;i++) {
-            entryOffset = dirStart + i*12 + 2;
-            tag = strings[file.getUint16(entryOffset, !bigEnd)];
-            if (!tag && debug) console.log("Unknown tag: " + file.getUint16(entryOffset, !bigEnd));
             if (tag !== undefined) {
                 tagValue = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
                 if (tagValue > 65535) { // tag value should not be more than max unsigned 16-bit integer

--- a/exif.js
+++ b/exif.js
@@ -571,6 +571,23 @@
             if (!tag && debug) console.log("Unknown tag: " + file.getUint16(entryOffset, !bigEnd));
             tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
         }
+
+        for (i=0;i<entries;i++) {
+            entryOffset = dirStart + i*12 + 2;
+            tag = strings[file.getUint16(entryOffset, !bigEnd)];
+            if (!tag && debug) console.log("Unknown tag: " + file.getUint16(entryOffset, !bigEnd));
+            if (tag !== undefined) {
+                tagValue = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
+                if (tagValue > 65535) { // tag value should not be more than max unsigned 16-bit integer
+                    if (debug) {
+                        console.log("Offset is outside the bounds of the DataView");
+                    }
+                    else {
+                        tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
+                    }
+                }
+            }
+        }
         return tags;
     }
 


### PR DESCRIPTION
Adds a check for undefined tags and tag values that exceed the max unsigned 16-bit integer value.