### PR TITLE
Handle XMP tags

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -1063,7 +1063,11 @@
 
     EXIF.readFromBinaryFile = function(file) {
         var exif = findEXIFinJPEG(file);
-        if (!exif) {
+        if (exif) {
+            if (EXIF.isXmpEnabled) {
+                exif.xmpData = findXMPinJPEG(file)
+            }
+        } else {
             var dataView = new DataView(file);
             exif = readEXIFDataFromTIFF(dataView, 0);
             if (EXIF.isXmpEnabled && exif.XMP) {

--- a/exif.js
+++ b/exif.js
@@ -750,10 +750,13 @@
             return false;
         }
 
+        return readEXIFDataFromTIFF(file, start + 6);
+    }
+
+    function readEXIFDataFromTIFF(file, tiffOffset) {
         var bigEnd,
             tags, tag,
-            exifData, gpsData,
-            tiffOffset = start + 6;
+            exifData, gpsData;
 
         // test for TIFF validity and endianness
         if (file.getUint16(tiffOffset) == 0x4949) {
@@ -1047,7 +1050,13 @@
     }
 
     EXIF.readFromBinaryFile = function(file) {
-        return findEXIFinJPEG(file);
+        var exif = findEXIFinJPEG(file);
+        if (!exif) {
+            var dataView = new DataView(file);
+            exif = readEXIFDataFromTIFF(dataView, 0);
+        }
+
+        return exif;
     }
 
     if (typeof define === 'function' && define.amd) {

--- a/exif.js
+++ b/exif.js
@@ -128,7 +128,8 @@
         0x0110 : "Model",
         0x0131 : "Software",
         0x013B : "Artist",
-        0x8298 : "Copyright"
+        0x8298 : "Copyright",
+        0x02BC : "XMP"
     };
 
     var GPSTags = EXIF.GPSTags = {
@@ -756,7 +757,7 @@
     function readEXIFDataFromTIFF(file, tiffOffset) {
         var bigEnd,
             tags, tag,
-            exifData, gpsData;
+            exifData, gpsData, xmpData;
 
         // test for TIFF validity and endianness
         if (file.getUint16(tiffOffset) == 0x4949) {
@@ -839,6 +840,14 @@
         // extract thumbnail
         tags['thumbnail'] = readThumbnailImage(file, tiffOffset, firstIFDOffset, bigEnd);
 
+        if (tags['XMP']) {
+            xmpData = ''
+            for (var i = 0; i < tags['XMP'].length; i++) {
+                xmpData += String.fromCharCode(tags['XMP'][i]);
+            }
+            tags['XMP'] = xmpData;
+        }
+
         return tags;
     }
 
@@ -857,8 +866,7 @@
         }
 
         var offset = 2,
-            length = file.byteLength,
-            dom = new DOMParser();
+            length = file.byteLength;
 
         while (offset < (length-4)) {
             if (getStringFromDB(dataView, offset, 4) == "http") {
@@ -867,30 +875,34 @@
                 var xmpString = getStringFromDB(dataView, startOffset, sectionLength)
                 var xmpEndIndex = xmpString.indexOf('xmpmeta>') + 8;
                 xmpString = xmpString.substring( xmpString.indexOf( '<x:xmpmeta' ), xmpEndIndex );
-
-                var indexOfXmp = xmpString.indexOf('x:xmpmeta') + 10
-                //Many custom written programs embed xmp/xml without any namespace. Following are some of them.
-                //Without these namespaces, XML is thought to be invalid by parsers
-                xmpString = xmpString.slice(0, indexOfXmp)
-                            + 'xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/" '
-                            + 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-                            + 'xmlns:tiff="http://ns.adobe.com/tiff/1.0/" '
-                            + 'xmlns:plus="http://schemas.android.com/apk/lib/com.google.android.gms.plus" '
-                            + 'xmlns:ext="http://www.gettyimages.com/xsltExtension/1.0" '
-                            + 'xmlns:exif="http://ns.adobe.com/exif/1.0/" '
-                            + 'xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" '
-                            + 'xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#" '
-                            + 'xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/" '
-                            + 'xmlns:xapGImg="http://ns.adobe.com/xap/1.0/g/img/" '
-                            + 'xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/" '
-                            + xmpString.slice(indexOfXmp)
-
-                var domDocument = dom.parseFromString( xmpString, 'text/xml' );
-                return xml2Object(domDocument);
+                return parseXmpString(xmpString);
             } else{
              offset++;
             }
         }
+    }
+
+    function parseXmpString(xmpString) {
+        var dom = new DOMParser()
+        var indexOfXmp = xmpString.indexOf('x:xmpmeta') + 10
+        //Many custom written programs embed xmp/xml without any namespace. Following are some of them.
+        //Without these namespaces, XML is thought to be invalid by parsers
+        xmpString = xmpString.slice(0, indexOfXmp)
+                    + 'xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/" '
+                    + 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+                    + 'xmlns:tiff="http://ns.adobe.com/tiff/1.0/" '
+                    + 'xmlns:plus="http://schemas.android.com/apk/lib/com.google.android.gms.plus" '
+                    + 'xmlns:ext="http://www.gettyimages.com/xsltExtension/1.0" '
+                    + 'xmlns:exif="http://ns.adobe.com/exif/1.0/" '
+                    + 'xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" '
+                    + 'xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#" '
+                    + 'xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/" '
+                    + 'xmlns:xapGImg="http://ns.adobe.com/xap/1.0/g/img/" '
+                    + 'xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/" '
+                    + xmpString.slice(indexOfXmp)
+
+        var domDocument = dom.parseFromString( xmpString, 'text/xml' );
+        return xml2Object(domDocument);
     }
 
     function xml2json(xml) {
@@ -1054,6 +1066,9 @@
         if (!exif) {
             var dataView = new DataView(file);
             exif = readEXIFDataFromTIFF(dataView, 0);
+            if (EXIF.isXmpEnabled && exif.XMP) {
+                exif.xmpData = parseXmpString(exif.XMP)
+            }
         }
 
         return exif;


### PR DESCRIPTION
This builds upon #195 and adds support for handling XMP when it is embedded as a tag. This is needed to handle XMP data in TIFF images.