### PR TITLE
Add support for data type 13 (IFD offset)

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -614,6 +614,7 @@
                 }
 
             case 4: // long, 32 bit int
+            case 13: // IFD offset, long, 32 bit int (see https://owl.phy.queensu.ca/~phil/exiftool/standards.html)
                 if (numValues == 1) {
                     return file.getUint32(entryOffset + 8, !bigEnd);
                 } else {


### PR DESCRIPTION
Some cameras (Sequoia Parrot in my case) use the non-standard tag type `13` to indicate an offset to an IFD, as recommended on ExifTools homepage here: https://owl.phy.queensu.ca/~phil/exiftool/standards.html (see section "TIFF 6.0" / "A simple solution").

For exif-js' purpose, the only change needed to handle this is simply to treat data type 13 the same as data type 4. With this change, I can read GPS information from the Sequoia Parrot camera (without the change the GPS IFD is ignored by exif-js). ExifTool does the same, so this should be safe to do.