### PR TITLE
- only read tag value if tag is known

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -569,7 +569,7 @@
             entryOffset = dirStart + i*12 + 2;
             tag = strings[file.getUint16(entryOffset, !bigEnd)];
             if (!tag && debug) console.log("Unknown tag: " + file.getUint16(entryOffset, !bigEnd));
-            tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
+            if (tag) tags[tag] = readTagValue(file, entryOffset, tiffStart, dirStart, bigEnd);
         }
         return tags;
     }


### PR DESCRIPTION
Hi there, I fixed this exception with an image of ours:

exif.js:595 Uncaught RangeError: Offset is outside the bounds of the DataView
    at DataView.getUint8 (<anonymous>)
    at readTagValue (exif.js:595)
    at readTags (exif.js:572)
    at readThumbnailImage (exif.js:700)
    at readEXIFData (exif.js:837)
    at findEXIFinJPEG (exif.js:449)
    at handleBinaryFile (exif.js:370)
    at XMLHttpRequest.http.onload (exif.js:400)

I only read the tag values if the tag variable is actually valid.