### PR TITLE
Use currentSrc if possible 

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -380,17 +380,18 @@
             }
         }
 
-        if (img.src) {
-            if (/^data\:/i.test(img.src)) { // Data URI
-                var arrayBuffer = base64ToArrayBuffer(img.src);
+        if (img.currentSrc || img.src) {
+            var src = img.currentSrc || img.src;
+            if (/^data\:/i.test(src)) { // Data URI
+                var arrayBuffer = base64ToArrayBuffer(src);
                 handleBinaryFile(arrayBuffer);
 
-            } else if (/^blob\:/i.test(img.src)) { // Object URL
+            } else if (/^blob\:/i.test(src)) { // Object URL
                 var fileReader = new FileReader();
                 fileReader.onload = function(e) {
                     handleBinaryFile(e.target.result);
                 };
-                objectURLToBlob(img.src, function (blob) {
+                objectURLToBlob(src, function (blob) {
                     fileReader.readAsArrayBuffer(blob);
                 });
             } else {
@@ -403,7 +404,7 @@
                     }
                     http = null;
                 };
-                http.open("GET", img.src, true);
+                http.open("GET", src, true);
                 http.responseType = "arraybuffer";
                 http.send(null);
             }


### PR DESCRIPTION
When using [responsive images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images), exif-JS will GET the picture from the `src` contained in the `img` node instead of the URL of the picture currently displayed and cached by the browser.

For example, in this [sample project](https://stackblitz.com/edit/angular-exif-js-currentsrc) exif-JS will always GET `DSC04762.jpg` while `DSC04762-xxx.jpg` is currently displayed, defeating the use of the browser's cache by downloading the picture twice (which we should try to avoid as much as possible in an era of bandwidth-limited smartphones).


So I propose to use `HtmlElementImage`'s  [`currentSrc`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/currentSrc) instead of `src` when available, and revert back to using `src` if the browser does not support `currentSrc`.