### PR TITLE
getStringFromDB: Do not read after null terminator

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -739,6 +739,8 @@
     function getStringFromDB(buffer, start, length) {
         var outstr = "";
         for (var n = start; n < start+length; n++) {
+            // stop on null terminator, if necessary
+            if (buffer.getUint8(n) === 0) break;
             outstr += String.fromCharCode(buffer.getUint8(n));
         }
         return outstr;


### PR DESCRIPTION
This matches behavior in exiftool. See https://github.com/exiftool/exiftool/blob/2f235f9a5618336f199c6481b452836c55de6b0c/lib/Image/ExifTool.pm#L5226