### PR TITLE
type fix

### DIFF
--- a/exif.d.ts
+++ b/exif.d.ts
@@ -1,5 +1,5 @@
 interface EXIFStatic {
-    getData(url: string, callback: any): any;
+    getData(url: string | HTMLImageElement, callback: any): any;
     getTag(img: any, tag: any): any;
     getAllTags(img: any): any;
     pretty(img: any): string;


### PR DESCRIPTION
img can be HTMLImageElement

```
    EXIF.getData = function(img, callback) {
        if (((self.Image && img instanceof self.Image)
            || (self.HTMLImageElement && img instanceof self.HTMLImageElement))
            && !img.complete)
            return false;

        if (!imageHasData(img)) {
            getImageData(img, callback);
        } else {
            if (callback) {
                callback.call(img);
            }
        }
        return true;
    }
```