### PR TITLE
Fix type signature of getData

### DIFF
--- a/exif.d.ts
+++ b/exif.d.ts
@@ -1,5 +1,5 @@
 interface EXIFStatic {
-    getData(url: string, callback: any): any;
+    getData(url: (string|HTMLImageElement|typeof Image), callback: any): any;
     getTag(img: any, tag: any): any;
     getAllTags(img: any): any;
     pretty(img: any): string;

--- a/exif.d.ts
+++ b/exif.d.ts
@@ -1,5 +1,5 @@
 interface EXIFStatic {
-    getData(url: (string|HTMLImageElement|typeof Image), callback: any): any;
+    getData(url: (string|HTMLImageElement|typeof Image), callback: any): Boolean;
     getTag(img: any, tag: any): any;
     getAllTags(img: any): any;
     pretty(img: any): string;


### PR DESCRIPTION
Image and HTMLImageElement are handled in https://github.com/exif-js/exif-js/blob/master/exif.js#L976-L980

This fixes errors like:
```

Error: src/xx.ts:99:30 - error TS2345: Argument of type 'HTMLImageElement' is not assignable to parameter of type 'string'.

99                 Exif.getData(imgObj, () => {
                                ~~~~~~
```