### PR TITLE
Add File to type definition of url for getData

### DIFF
--- a/exif.d.ts
+++ b/exif.d.ts
@@ -1,5 +1,5 @@
 interface EXIFStatic {
-    getData(url: string, callback: any): any;
+    getData(url: string | File, callback: any): any;
     getTag(img: any, tag: any): any;
     getAllTags(img: any): any;
     pretty(img: any): string;


### PR DESCRIPTION
Add the File type to the type definition of getData url. This is to prevent linting warnings, as the function works with File objects.